### PR TITLE
Remove unnecessary info endpoint from RSS routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,6 @@ curl http://localhost:3000/rss/UC_x5XG1OV2P6uZZ5FSM9Ttw?limit=10&minDuration=300
 curl http://localhost:3000/rss/@channelname?limit=none
 ```
 
-### Channel Information (Debug)
-```
-GET /rss/{channelIdentifier}/info
-```
-
-**Parameters:**
-- `channelIdentifier` - YouTube channel ID or handle
-
-**Query Parameters:** None
-
 ### Audio Streaming
 ```
 GET /audio/{videoId}

--- a/routes/rss.js
+++ b/routes/rss.js
@@ -168,31 +168,4 @@ router.get('/:channelIdentifier', async (req, res) => {
   }
 });
 
-// Get channel information (for testing/debugging)
-router.get('/:channelIdentifier/info', async (req, res) => {
-  try {
-    const { channelIdentifier } = req.params;
-    logger.debug('RSS', `Channel info request for: ${channelIdentifier}`);
-    
-    const channelInfo = await getChannelInfo(channelIdentifier);
-    
-    if (!channelInfo) {
-      logger.warn('RSS', `Channel info not found: ${channelIdentifier}`);
-      return res.status(404).json({ 
-        error: 'Channel not found' 
-      });
-    }
-
-    logger.info('RSS', `Channel info retrieved: ${channelInfo.title}`);
-    res.json(channelInfo);
-
-  } catch (error) {
-    logger.error('RSS', 'Channel info retrieval failed', { error: error.message, channelIdentifier });
-    res.status(500).json({ 
-      error: 'Failed to get channel information',
-      message: error.message 
-    });
-  }
-});
-
 export default router;


### PR DESCRIPTION
- Remove GET /rss/:channelIdentifier/info endpoint that was used for testing/debugging
- Update README.md to remove documentation for the removed endpoint
- Simplify API surface by keeping only essential endpoints