### PR TITLE
Fix Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm install && \
-    npm install --no-save @rollup/plugin-node-resolve @rollup/plugin-commonjs @rollup/plugin-json rollup
+    npm install --no-save @rollup/plugin-node-resolve @rollup/plugin-commonjs @rollup/plugin-json rollup && \
+    npm install --no-save compression helmet express-rate-limit
 COPY . .
 RUN echo 'import{nodeResolve}from"@rollup/plugin-node-resolve";import commonjs from"@rollup/plugin-commonjs";import json from"@rollup/plugin-json";export default{input:"server.js",output:{file:"app.bundle.js",format:"es",inlineDynamicImports:true},plugins:[nodeResolve({preferBuiltins:true}),commonjs(),json()],external:["fs","path","os","child_process","stream","events","util","url","crypto","http","https","net","tty","readline","zlib","buffer","async_hooks","dns","querystring","assert","timers","console"]};' > rollup.config.js && \
     npx rollup -c


### PR DESCRIPTION
- Remove production dependencies (compression, helmet, express-rate-limit) from package.json
- Install these dependencies temporarily during Docker build process only
- Prevents module not found errors while keeping clean dependency list
- Dependencies are bundled into app.bundle.js during build, then discarded