### PR TITLE
Remove embed/metadata flags and retry settings from all profiles

### DIFF
--- a/config/yt-dlp-profiles.json
+++ b/config/yt-dlp-profiles.json
@@ -8,13 +8,7 @@
     "additionalArgs": [
       "--no-playlist",
       "--format", "bestaudio[ext=webm]/bestaudio",
-      "--extractor-args", "youtube:player_client=default,-tv",
-      "--embed-thumbnail",
-      "--embed-metadata",
-      "--add-metadata",
-      "--embed-chapters",
-      "--retries", "3",
-      "--fragment-retries", "3"
+      "--extractor-args", "youtube:player_client=default,-tv"
     ]
   },
   "opus": {
@@ -26,13 +20,7 @@
     "additionalArgs": [
       "--no-playlist",
       "--format", "bestaudio",
-      "--extractor-args", "youtube:player_client=default,-tv",
-      "--embed-thumbnail",
-      "--embed-metadata",
-      "--add-metadata",
-      "--embed-chapters",
-      "--retries", "3",
-      "--fragment-retries", "3"
+      "--extractor-args", "youtube:player_client=default,-tv"
     ]
   },
   "mp3": {
@@ -44,13 +32,7 @@
     "additionalArgs": [
       "--no-playlist",
       "--format", "bestaudio/best",
-      "--extractor-args", "youtube:player_client=default,-tv",
-      "--embed-thumbnail",
-      "--embed-metadata",
-      "--add-metadata",
-      "--embed-chapters",
-      "--retries", "3",
-      "--fragment-retries", "3"
+      "--extractor-args", "youtube:player_client=default,-tv"
     ]
   },
   "high_quality_opus": {
@@ -62,13 +44,7 @@
     "additionalArgs": [
       "--no-playlist",
       "--format", "bestaudio",
-      "--extractor-args", "youtube:player_client=default,-tv",
-      "--embed-thumbnail",
-      "--embed-metadata",
-      "--add-metadata",
-      "--embed-chapters",
-      "--retries", "3",
-      "--fragment-retries", "3"
+      "--extractor-args", "youtube:player_client=default,-tv"
     ]
   },
   "aac": {
@@ -80,13 +56,7 @@
     "additionalArgs": [
       "--no-playlist",
       "--format", "bestaudio",
-      "--extractor-args", "youtube:player_client=default,-tv",
-      "--embed-thumbnail",
-      "--embed-metadata",
-      "--add-metadata",
-      "--embed-chapters",
-      "--retries", "3",
-      "--fragment-retries", "3"
+      "--extractor-args", "youtube:player_client=default,-tv"
     ]
   }
 }


### PR DESCRIPTION
- Removed --embed-thumbnail, --embed-metadata, --add-metadata, --embed-chapters from all profiles
- These flags don't work with stdout streaming (--output -) used in conversion pipeline
- Removed --retries and --fragment-retries to use yt-dlp defaults (10 and infinite)
- Fixes: ERROR: [Errno 13] Permission denied: '-.webp'